### PR TITLE
Switching to gds_py:2.0 stable

### DIFF
--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM darribas/gds_py:2.0rc4
+FROM darribas/gds_py:2.0
 
 LABEL maintainer="Dani Arribas-Bel <d.arribas-bel@liverpool.ac.uk>"
 


### PR DESCRIPTION
New PR to bring in the move to `darribas/gds_py:2.0`