### PR TITLE
update tracking ID for geographicdatascience org account

### DIFF
--- a/infrastructure/booksite/_config.yml
+++ b/infrastructure/booksite/_config.yml
@@ -90,7 +90,7 @@ scholar:
 
 # Navigate to https://analytics.google.com, add a new property for your jupyter book and copy the tracking id here.
 google_analytics:
-  mytrackingcode: UA-25436886-4
+  mytrackingcode: UA-146598819-1
 
 #######################################################################################
 # Jupyter book settings you probably don't need to change


### PR DESCRIPTION
This moves the analytics to the `geographicdatascience@gmail.com` account. This may need tweaking, so I'm not sure if we want to leave it as currently configured for the launch, and then clean it up afterwards?