### PR TITLE
Try roboto family throughout for font families

### DIFF
--- a/infrastructure/website_content/_static/custom.css
+++ b/infrastructure/website_content/_static/custom.css
@@ -1,8 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond&family=EB+Garamond&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab&family=Roboto+Mono&display=swap');
 
 body {
-    font-family: 'Cormorant Garamond', serif;
-    font-family: 'EB Garamond', serif;
+    font-family: 'Roboto Slab', serif;
+    font-family: 'Roboto Mono', monospace;
+    font-family: 'Roboto', sans-serif;
     font-size: 24px;
-    font-weight: 500;
+    font-weight: 400;
 }


### PR DESCRIPTION
We could try using an entire family for self-consistent fonts. 

Here, I'm setting the serif, sans-serif, and monospace to all come from the Roboto family. 
