### PR TITLE
checkin start of matplotlibrc

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,0 +1,3 @@
+figure.dpi : 100
+figure.autolayout : True
+


### PR DESCRIPTION
This ensures that the dpi of all generated figures is 100 and that the figure tight_layout() is always True. 

I'm not quite sure yet if this is actually used when running the notebook, though?